### PR TITLE
Cache the methods to free the native objects, per class

### DIFF
--- a/src/main/java/com/jme3/bullet/NpoTracker.java
+++ b/src/main/java/com/jme3/bullet/NpoTracker.java
@@ -93,7 +93,7 @@ class NpoTracker extends WeakReference<NativePhysicsObject> {
         NativePhysicsObject.removeTracker(id);
         Method[] methods = FreeingMethods.of(referentClass);
         // Avoid re-boxing if there is more than one method to call.
-        Long boxedId = Long.valueOf(id);
+        Object[] boxedId = new Object[]{ Long.valueOf(id) };
         for (int i = 0; i < methods.length; ++i) {
             Method method = methods[i];
             try {

--- a/src/main/java/com/jme3/bullet/NpoTracker.java
+++ b/src/main/java/com/jme3/bullet/NpoTracker.java
@@ -34,6 +34,8 @@ package com.jme3.bullet;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Logger;
 
 /**


### PR DESCRIPTION
Hi! While I was inspecting how the native interop worked in this library, I noticed that it worked in a peculiar way when freeing native objects.

There is the weak reference queue that gets emptied by a background thread, but I see it relies on reflection to call the respective freeing methods of the hierarchy of each object that gets freed.

I think it's quite easy to cache this process instead of reflecting and navigating the hierarchy on every single free call. I avoided using computeIfAbsent since it seems you deploy on Java 1.7. I know it's a bit defensive to use a ConcurrentHashMap for the cache since it always is called from the same thread but it seemed appropriate.

I haven't tested this extensively. Just ran the buid/tests on my Linux x64 machine and they passed.

As a note I thiiiink this whole process could be avoided by moving things around a bit, having each object implement a free method instead of relying of reflecting over a hierarchy of static methods. It's just that this change seemed much easier to implement in the meanwhile.

I'm a bit new to git, PRs and so on so sorry for any inconvenience.
