### PR TITLE
fix: include stdint.h to avoid errors on GCC

### DIFF
--- a/src/main/native/v-hacd/inc/vhacdICHull.h
+++ b/src/main/native/v-hacd/inc/vhacdICHull.h
@@ -17,6 +17,7 @@
 #define VHACD_ICHULL_H
 #include "vhacdManifoldMesh.h"
 #include "vhacdVector.h"
+#include <stdint.h>
 
 namespace VHACD {
 //!    Incremental Convex Hull algorithm (cf. http://cs.smith.edu/~orourke/books/ftp.html ).

--- a/src/main/native/v-hacd/inc/vhacdVolume.h
+++ b/src/main/native/v-hacd/inc/vhacdVolume.h
@@ -18,6 +18,7 @@
 #include "vhacdMesh.h"
 #include "vhacdVector.h"
 #include <assert.h>
+#include <stdint.h>
 
 #ifdef _MSC_VER
 #pragma warning(push)

--- a/src/main/native/v-hacd/src/vhacdICHull.cpp
+++ b/src/main/native/v-hacd/src/vhacdICHull.cpp
@@ -14,6 +14,7 @@
  */
 #include "vhacdICHull.h"
 #include <limits>
+#include <cstdint>
 
 #ifdef _MSC_VER
 #pragma warning(disable:4456 4706)


### PR DESCRIPTION
After GCC12, types_t(like int32_t, uint8_t) is no longer builtin and should be included explicitly.