### PR TITLE
push.yml:  test on Windows_ARM64

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -184,6 +184,38 @@ jobs:
             -u '${{ secrets.CENTRAL_USERNAME }}'
         shell: bash
 
+  Java21-Windows_ARM64:
+    if: contains(toJson(github.event.commits), '[ci skip] ') == false
+    runs-on: windows-11-vs2026-arm
+    steps:
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'zulu'
+          java-version: 21
+      - uses: actions/checkout@v6
+      - uses: gradle/actions/setup-gradle@v6
+      - run: |
+          ./gradlew -Pbt=Debug -Pflavor=Sp -Ptarget=Windows_ARM64 run build install \
+            --console=plain \
+            -PsigningKeyEncoded='${{ secrets.SIGNING_KEY_ENCODED }}' \
+            -PsigningPassword='${{ secrets.SIGNING_PASSWORD }}'
+        shell: bash
+      - if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          ./gradlew -Partifact=Libbulletjme-Windows_ARM64 -Ptarget=Windows_ARM64 clean release \
+            --console=plain \
+            -PsigningKeyEncoded='${{ secrets.SIGNING_KEY_ENCODED }}' \
+            -PsigningPassword='${{ secrets.SIGNING_PASSWORD }}' \
+            -PcentralPassword='${{ secrets.CENTRAL_PASSWORD }}' \
+            -PcentralUsername='${{ secrets.CENTRAL_USERNAME }}'
+        shell: bash
+      - name: uploadToCentral.sh
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          bash/uploadToCentral.sh -p '${{ secrets.CENTRAL_PASSWORD }}' \
+            -u '${{ secrets.CENTRAL_USERNAME }}'
+        shell: bash
+
   Java21-x-Android:
     if: contains(toJson(github.event.commits), '[ci skip] ') == false
     runs-on: ubuntu-24.04


### PR DESCRIPTION
This augments the GitHub CI script with a new job to test and release on the Windows_ARM64 platform. The next release should include a new Maven artifact ID for that platform.